### PR TITLE
Switch to positron base map

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -218,7 +218,7 @@ class CatalogController < ApplicationController
     # 'mapquest' http://developer.mapquest.com/web/products/open/map
     # 'positron' http://cartodb.com/basemaps/
     # 'darkMatter' http://cartodb.com/basemaps/
-    config.basemap_provider = 'mapquest'
+    config.basemap_provider = 'positron'
   end
 
 


### PR DESCRIPTION
Since the change of policy by MapQuest about use of its base maps that
took effect on 2016-07-11
(http://devblog.mapquest.com/2016/06/15/modernization-of-mapquest-result
s-in-changes-to-open-tile-access/) that means we no longer get easy
access to tile data, we switch for now to another base map provided by
GeoBlacklight: positron.
