### PR TITLE
switch from MapQuest to OpenStreetMap for base map

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -218,7 +218,7 @@ class CatalogController < ApplicationController
     # 'mapquest' http://developer.mapquest.com/web/products/open/map
     # 'positron' http://cartodb.com/basemaps/
     # 'darkMatter' http://cartodb.com/basemaps/
-    config.basemap_provider = 'mapquest'
+    config.basemap_provider = 'positron'
 
     # Add contact link to navbar
     config.add_nav_action(:contact, partial: 'blacklight/nav/contact')


### PR DESCRIPTION
Switch from MapQuest to OpenStreetMap for base map as a result of MapQuest cutting off non-registered access to direct tiles.

<img width="1425" alt="screen shot 2016-07-12 at 9 34 57 am" src="https://cloud.githubusercontent.com/assets/1202435/16779504/93ff993a-4840-11e6-883d-d2c5d9123166.png">

<img width="1423" alt="screen shot 2016-07-12 at 2 53 39 pm" src="https://cloud.githubusercontent.com/assets/1202435/16779509/9c8a52ac-4840-11e6-93eb-2390e1bf693b.png">
