### PR TITLE
switch to asset pipeline handler for image

### DIFF
--- a/app/assets/stylesheets/vt_overrides/header.css.scss
+++ b/app/assets/stylesheets/vt_overrides/header.css.scss
@@ -6,6 +6,6 @@
   border-color: $hokie-orange;
 }
 #header-navbar .navbar-brand {
-  background-image: url('/assets/vt_overrides/vt_logo.svg');
+  background-image: image-url('vt_overrides/vt_logo.svg');
   background-position: center left;
 }


### PR DESCRIPTION
Switch to using image-url helper to get header logo image to precompile and be referenced correctly in production. ...Oops.
