### PR TITLE
Log to Graylog server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,5 @@ gem 'devise'
 gem 'devise-guests', '~> 0.5'
 group :development, :test do
 end
+gem "gelf"
+gem "lograge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     font-awesome-rails (4.6.3.1)
       railties (>= 3.2, < 5.1)
+    gelf (3.0.0)
+      json
     geoblacklight-icons (0.3.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -118,6 +120,10 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     leaflet-rails (0.7.7)
+    lograge (0.4.1)
+      actionpack (>= 4, < 5.1)
+      activesupport (>= 4, < 5.1)
+      railties (>= 4, < 5.1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -224,9 +230,11 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   devise
   devise-guests (~> 0.5)
+  gelf
   geoblacklight!
   jbuilder (~> 2.0)
   jquery-rails
+  lograge
   rails (= 4.2.6)
   rsolr (~> 1.0)
   sass-rails (~> 5.0)
@@ -239,4 +247,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.2

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,4 +81,27 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  if Rails.application.secrets['graylog']['enabled'] == true
+    graylog_settings = Rails.application.secrets['graylog']
+    graylog_host = graylog_settings['host'] || '127.0.0.1'
+    graylog_port = graylog_settings['port'] || 12201
+    graylog_network_locality = graylog_settings['network_locality'] || :WAN
+    graylog_protocol = graylog_settings['protocol'] || 'udp'
+    graylog_protocol = graylog_protocol.downcase == 'tcp' ? GELF::Protocol::TCP : GELF::Protocol::UDP
+    graylog_facility = graylog_settings['facility']
+    graylog_verbosity = graylog_settings['verbosity'] || 'info'
+
+    config.lograge.enabled = true
+    config.lograge.formatter = Lograge::Formatters::Graylog2.new
+    config.logger = GELF::Logger.new(graylog_host, graylog_port,
+        graylog_network_locality, { :protocol => graylog_protocol,
+                                    :facility => graylog_facility })
+    config.log_level = graylog_verbosity
+    config.colorize_logging = false
+    # Log controller params, too
+    config.lograge.custom_options = lambda do |event|
+      params = event.payload[:params].reject { |k| %w(controller action).include?(k) }
+      { "params" => params }
+    end
+  end
 end


### PR DESCRIPTION
Change production logging to log to a Graylog server GELF input.  The
Graylog server settings are specified in config/secrets.yml under a
"graylog" key.  The "enabled" key under "graylog" must be set to "true"
to enable Graylog logging, otherwise the default Rails logger is used.
The Ansible InstallScripts set an appropriate default.

We only enable Graylog logging for RAILS_ENV="production" mode by
adding the code to set it up to config/environments/production.rb.

We use the "gelf" and "lograge" gems to do the logging.  This is per
the Graylog documentation on how to ingest Rails logs into Graylog.
Note that the "lograge" gem produces much more concise logging than
the standard Rails logger.
