### PR TITLE
Upgrade vulnerable Gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     config (1.2.1)
       activesupport (>= 3.0)
       deep_merge (~> 1.0, >= 1.0.1)
-    crass (1.0.3)
+    crass (1.0.4)
     debug_inspector (0.0.2)
     deep_merge (1.1.1)
     deprecation (1.0.0)
@@ -125,7 +125,7 @@ GEM
       actionpack (>= 4, < 5.1)
       activesupport (>= 4, < 5.1)
       railties (>= 4, < 5.1)
-    loofah (2.1.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -158,8 +158,8 @@ GEM
       activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (4.2.10)
       actionpack (= 4.2.10)
       activesupport (= 4.2.10)
@@ -245,4 +245,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
The existing versions of "loofah" and "rails-html-sanitizer" Gems have XSS vulnerabilities (see https://github.com/flavorjones/loofah/issues/144 and https://nvd.nist.gov/vuln/detail/CVE-2018-3741).  This change updates the Gems to address these vulnerabilities.