### PR TITLE
Upgrade sprockets due to security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
-    rack (1.6.8)
+    rack (1.6.10)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.10)
@@ -189,7 +189,7 @@ GEM
       ruby-progressbar
       rubyzip
     spring (1.7.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -245,4 +245,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.16.2
+   1.16.3


### PR DESCRIPTION
# What does this Pull Request do?

Upgrades the current version of the `sprockets` Gem due to [CVE-2018-3760](https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k)

# What's the changes?

The version of the `sprockets` Gem in `Gemfile.lock` is upgraded from version 3.7.1 to 3.7.2.

# How should this be tested?

Deploy the `geoblacklight` application in `production` mode and check that it is running correctly.

# Interested parties
@yinlinchen 