### PR TITLE
Address security vulnerabilities in gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       actionpack (>= 4, < 5.1)
       activesupport (>= 4, < 5.1)
       railties (>= 4, < 5.1)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -135,10 +135,10 @@ GEM
     minitest (5.11.3)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.10)
@@ -173,7 +173,7 @@ GEM
     rsolr (1.1.1)
       builder (>= 2.1.2)
     ruby-progressbar (1.8.1)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -245,4 +245,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.16.3
+   1.17.1


### PR DESCRIPTION
**Address security vulnerabilities in gems**
* * *

# What does this Pull Request do?
Update gems to address security vulnerabilities in the following gems:

- rack: CVE-2018-16471
- loofah: CVE-2018-16468
- rubyzip: CVE-2018-1000544

# What's the changes?
Performed a `bundle update rack loofah rubyzip` to update the aforementioned gems past their current vulnerable versions.

# How should this be tested?

Deploy this version of `geoblacklight` and verify it still works.

# Interested parties
@VTUL/dld-dev 