### PR TITLE
revert to official geoblacklight schema restrictions

### DIFF
--- a/lib/geoblacklight/dataingest.rb
+++ b/lib/geoblacklight/dataingest.rb
@@ -13,24 +13,25 @@ class DataIngest
     "dc_rights_s": {required: true},
     "dct_provenance_s": {required: true},
     "dct_references_s": {required: false},
-    "dc_creator_sm": {required: true},
-    "dc_language_sm": {required: true},
-    "dc_publisher_sm": {required: true},
-    "dc_type_s": {required: true},
-    "dct_spatial_sm": {required: true},
+    "dc_creator_sm": {required: false},
+    "dc_language_sm": {required: false},
+    "dc_publisher_sm": {required: false},
+    "dc_type_s": {required: false},
+    "dct_spatial_sm": {required: false},
     "dct_temporal_sm": {required: false},
     "dct_issued_dt": {required: false},
-    "dct_ispartof_sm": {required: true},
+    "dct_ispartof_sm": {required: false},
     "solr_geom": {required: true},
     "georss:polygon": {required: false},
     "dc_title_s": {required: true},
-    "dc_description_s": {required: true},
-    "dc_format_s": {required: true},
+    "dc_description_s": {required: false},
+    "dc_format_s": {required: false},
     "dc_subject_sm": {required: false},
-    "layer_id_s": {required: true},
+    "layer_id_s": {required: false},
     "layer_modified_dt": {required: false},
     "layer_slug_s": {required: true},
-    "layer_geom_type_s": {required: true}
+    "layer_geom_type_s": {required: false},
+    "geoblacklight_version": {required: true}
   }
     
   def createreport(filename, content)
@@ -178,24 +179,20 @@ class DataIngest
             puts "Processing row #{index.to_s}"
             errmsg = validaterecord(row)
             if errmsg.length > 0
-              errorcontent += "row " + index.to_s + ": " + errmsg + "\n\n"
+              errorcontent += "row " + (index + 1).to_s + ": " + errmsg + "\n\n"
             else
               solrdata = formatsolrdata(row)
               begin
                 Blacklight.default_index.connection.add(solrdata)
                 Blacklight.default_index.connection.commit
                 ingestedrecs += 1
-              rescue
-                errorcontent += "row #{index.to_s}: There was an error committing this record to solr\n\n"
+              rescue StandardError => e 
+		errorcontent += "row #{(index + 1).to_s}: There was an error committing this record to solr. Message: #{e.message}\n\n"
               end
             end
 
             totalrecs += 1
             index += 1
-            if totalrecs - ingestedrecs >= 20
-              errorcontent += "#{uploadfile} exceeded the error limit. Quitting after line #{index}."
-              break
-            end
           end
         end        
 


### PR DESCRIPTION
**Change schema to match official geoblacklight schema. Improve logging.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1757) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
https://webapps.es.vt.edu/jira/browse/LIBTD-1721

# What does this Pull Request do? (:star:)
Change schema to match official geoblacklight schema. Improve logging. Remove restriction on 20 invalid lines per file.

# What's the changes? (:star:)
* Change schema to match official geoblacklight schema. 
* Add solr exception message to improve logging. 
* Remove restriction on 20 invalid lines per file.

# How should this be tested?
* switch to user `railsapps`
* Copy the two files in the attached zip to `/opt/sftp/geodata/Upload`
[testing_files.zip](https://github.com/VTUL/geoblacklight/files/3019243/testing_files.zip)

* From the project root `/var/local/hydra/geoblacklight` run: `bundle exec rake vtul:geoblacklight:data_ingest' (user should still be railsapps)
* Check that the records in `dmf_20181120_MVP_fixed.csv` are ingested successfully
* Check that the records in `dmf_20180626_Virgina_Tech_Campus_Basemap_2017.csv` cause errors. Errors can be checked in `/opt/sftp/geodata/Report/Errors`

# Additional Notes:
* branch: `LIBTD-1757`

# Interested parties
@yinlinchen 

(:star:) Required fields
