### PR TITLE
Add log rotation to standard logfile

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,5 +103,11 @@ Rails.application.configure do
       params = event.payload[:params].reject { |k| %w(controller action).include?(k) }
       { "params" => params }
     end
+  else
+    # Create a standard logger that writes to log/production.log and rotates them.
+    # This ages the logfile once it reaches a certain size. Leave 12 “old” log files where 
+    # each file is about 10485760 bytes.
+    config.logger = Logger.new(Rails.root.join('log', "#{Rails.env}.log"), 12, 10485760)
+    config.log_level = :warn
   end
 end


### PR DESCRIPTION
If the option to log to Graylog is not chosen then the default is to
log to the standard Rails log file.  This file, by default, uses no
rotation and thus grows unbounded in size.  This change enables
options on the standard Rails logfile to rotate it every 10 MiB and
to keep the last 12 logfiles.

This change is being added because enabling the `graylog:enabled`
option in `secrets.yml` now appears to cause the application to
fail to work, hence a sane alternative for local logging is desirable.